### PR TITLE
Minor Fixes

### DIFF
--- a/glorious_sides96.h
+++ b/glorious_sides96.h
@@ -7,7 +7,7 @@ void set_glorious_side_96(char glorious_side, uint8_t r, uint8_t g, uint8_t b){
     rgb[1] = g;
     rgb[2] = b;
     int* this_side;
-    if(glorious_side == 'r'){this_side = side1;}
+    if(glorious_side == 'l'){this_side = side1;}
     else {this_side = side2;}
     for(int i = 0; i < 9; i++ ){
         rgb_matrix_set_color(this_side[i], rgb[0], rgb[1], rgb[2]);

--- a/keymap.c
+++ b/keymap.c
@@ -173,7 +173,7 @@ uint32_t layer_state_set_user(uint32_t state) {
 void rgb_matrix_indicators_advanced_user(uint8_t led_min, uint8_t led_max) {
 
     if (IS_HOST_LED_ON(USB_LED_CAPS_LOCK)) {
-        RGB_MATRIX_INDICATOR_SET_COLOR(30, 255, 255, 255); //capslock key
+        RGB_MATRIX_INDICATOR_SET_COLOR(54, 255, 255, 255); //capslock key
     }
 
     switch(get_highest_layer(layer_state)){  // special handling per layer


### PR DESCRIPTION
CapsLock LED # was pointing to the wrong key
Side lights were reversed. 