### PR TITLE
Swapped KC_VOLD & KC_VOLU to match the keycaps

### DIFF
--- a/keymap.c
+++ b/keymap.c
@@ -97,7 +97,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   /* Keymap _FL: Function Layer
    */
 [_FL] = LAYOUT(
-    RESET,  KC_MYCM,  KC_WHOM,  KC_CALC,  KC_MSEL,  KC_MPRV,  KC_MRWD,  KC_MPLY,  KC_MSTP,  KC_MUTE,  KC_VOLU,  KC_VOLD,  _______,   KC_PSCR,  _______,  _______,  _______,  _______,
+    RESET,  KC_MYCM,  KC_WHOM,  KC_CALC,  KC_MSEL,  KC_MPRV,  KC_MRWD,  KC_MPLY,  KC_MSTP,  KC_MUTE,  KC_VOLD,  KC_VOLU,  _______,   KC_PSCR,  _______,  _______,  _______,  _______,
   _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,   _______,  _______,  _______,  _______,  _______,
   _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,   RESET,  _______,  _______,  _______,  _______,
   _______,  _______,  _______,  _______,  HAPPY_FRIDAY,  GOOD_MORNING,  _______,  _______,  _______,  _______,  _______,  _______,  _______,             _______,  _______,  _______,


### PR DESCRIPTION
Noticed the volume buttons were backwards today. Updated accordingly. @skitzo2000, I've been making some changes / customizations to this to fit my daily use. I'll upload my current version to another branch on my fork if you're interested. 
I've added a couple dynamic macros, as well as made some minor adjustments to the lighting. 
Thanks again for putting this together. All it took was this example for me to understand the callback functions and the custom lighting features. I think I'll add CapsWord and Mod_Tap next. 